### PR TITLE
Add support for sphinx_resibots_theme

### DIFF
--- a/sphinxcontrib/versioning/_templates/versions.html
+++ b/sphinxcontrib/versioning/_templates/versions.html
@@ -1,4 +1,4 @@
-{% if html_theme == 'sphinx_rtd_theme' %}
+{% if html_theme in ('sphinx_rtd_theme', 'sphinx_resibots_theme') %}
 <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="versions">
     <span class="rst-current-version" data-toggle="rst-current-version">
         <span class="fa fa-book"> Other Versions</span>


### PR DESCRIPTION
I'm using a modified version of sphinx_rtd_theme which is called sphinx_resibots_theme. The changes are mostly stylistic, with some tweaks like user-defined links in the sidebar.

To support this theme, only one little change had to be made in your really cool project. However, I could understand that you don't want everyone's personal theme to be integrated in this project. Maybe an other option would be to use an option in the command line. Should I work in the latter direction ?

Thanks a lot for your time and this cool software