### PR TITLE
Fix travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
         - export ${!TRAVIS*}
         - tox -e docsV
 python:
+  - 3.6
   - 3.5
   - 3.4
   - 3.3

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,10 @@ install_requires =
 name = sphinxcontrib
 
 [tox]
-envlist = lint,py{34,27}
+envlist = lint,py{27,33,34,35,36}
+
+[pytest]
+log_level=DEBUG
 
 [testenv]
 commands =


### PR DESCRIPTION
- Fix failing tests in python versions 2.7, 3.4, 3.5 by settting `log_level=DEBUG` for `pytest` (worked for 3.3 since it is still using the old `pytest-catchlog` dependency which was added to `pytest` and blacklisted in version [3.3](https://docs.pytest.org/en/latest/changelog.html#pytest-3-3-1-2017-12-05))
- Add python version 3.6 to the tests.