### PR TITLE
sphinx1.7+: ImportError workaround, allows to see help

### DIFF
--- a/sphinxcontrib/versioning/sphinx_.py
+++ b/sphinxcontrib/versioning/sphinx_.py
@@ -6,7 +6,12 @@ import multiprocessing
 import os
 import sys
 
-from sphinx import application, build_main, locale
+from sphinx import application, locale
+try:
+    from sphinx import build_main
+except ImportError:
+    # Sphinx 1.7+ ImportError fix
+    from sphinx.cmd.build import build_main
 from sphinx.builders.html import StandaloneHTMLBuilder
 from sphinx.config import Config as SphinxConfig
 from sphinx.errors import SphinxError


### PR DESCRIPTION
upstream merged + branch/commit renamed (https://github.com/sphinx-contrib/sphinxcontrib-versioning/pull/69)


UPD: add reproduce details
python 3.7.5

```
Package                       Version                                                  
----------------------------- ----------
...
Sphinx                        2.2.2      
sphinxcontrib-applehelp       1.0.1      
sphinxcontrib-devhelp         1.0.1      
sphinxcontrib-htmlhelp        1.0.2      
sphinxcontrib-jsmath          1.0.1      
sphinxcontrib-qthelp          1.0.2      
sphinxcontrib-serializinghtml 1.1.3      
sphinxcontrib-versioning      2.2.1      
...
```

```bash
$ venv/bin/sphinx-versioning --help
Traceback (most recent call last):
  File "venv/bin/sphinx-versioning", line 11, in <module>
    load_entry_point('sphinxcontrib-versioning', 'console_scripts', 'sphinx-versioning')()
  File ".../sphinxcontrib-versioning/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 489, in load_entry_point
  File ".../sphinxcontrib-versioning/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2793, in load_entry_point
  File ".../sphinxcontrib-versioning/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2411, in load
  File ".../sphinxcontrib-versioning/venv/lib/python3.7/site-packages/setuptools-40.8.0-py3.7.egg/pkg_resources/__init__.py", line 2417, in resolve
  File ".../sphinxcontrib-versioning/sphinxcontrib/versioning/__main__.py", line 13, in <module>
    from sphinxcontrib.versioning.routines import build_all, gather_git_info, pre_build, read_local_conf
  File ".../sphinxcontrib-versioning/sphinxcontrib/versioning/routines.py", line 11, in <module>
    from sphinxcontrib.versioning.sphinx_ import build, read_config
  File ".../sphinxcontrib-versioning/sphinxcontrib/versioning/sphinx_.py", line 9, in <module>
    from sphinx import application, build_main, locale
ImportError: cannot import name 'build_main' from 'sphinx'
```